### PR TITLE
Travis-CI: cleanup Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ script:
   - go test -race -v ./...
 
 go:
-  - "1.9"
-  - "1.10"
-  - "1.11"
-  - "1.12"
-  - "1.13"
+  # Keep the latest stable release at the top
+  # Keep 'tip' just under
+  # Because those two Go versions are the ones that interest us the most.
+  - "1.14.x"
   - tip
+  - "1.13.x"
+  - "1.12.x"
+  - "1.11.x"
+  - "1.10.x"
+  - "1.9.x"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 script:
   - go test -race -v ./...
 
+# For GOPATH build
+go_import_path: github.com/nxadm/tail
+
 go:
   # Keep the latest stable release at the top
   # Keep 'tip' just under


### PR DESCRIPTION
1. Add ".x" suffix to all Go versions so the latest patched version is used
2. Add 1.14.x
3. Sort Go version to put the latest at the top, so the most interesting tests are executed earlier by Travis
4. Add `go_import_path` to allow contributor to run the builds on Travis even for old Go versions that rely on GOPATH