### PR TITLE
Add timeouts to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       with:
           fetch-depth: 0
     - name: Test
-      run: go test -race -v -timeout 30s ./...
+      run: go test -race -v -timeout 2m ./...
     - name: Build lib
       run: go build
     - name: Build cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       with:
           fetch-depth: 0
     - name: Test
-      run: go test -race -v ./...
+      run: go test -race -v -timeout 30s ./...
     - name: Build lib
       run: go build
     - name: Build cmd


### PR DESCRIPTION
Due to an issue with my previous PR, the tests got stuck and I had to wait 10 minutes for an Actions timeout. It would be good to add timeouts to the suite itself, I use this in other projects to trigger failures early on.

I'm not sure 30s is sufficient, I only tested this on macOS and Debian, but we'll see soon enough.