### PR TITLE
Update location after read

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -298,10 +298,12 @@ func (tail *Tail) tailFileSync() {
 		// do not seek in named pipes
 		if !tail.Pipe {
 			// grab the position in case we need to back up in the event of a half-line
-			if _, err := tail.Tell(); err != nil {
+			offset, err := tail.Tell()
+			if err != nil {
 				tail.Kill(err)
 				return
 			}
+			tail.Location = &SeekInfo{Offset: offset, Whence: io.SeekStart}
 		}
 
 		line, err := tail.readLine()


### PR DESCRIPTION
When tailing without following, Tell() is not available due to the file handle already being closed. Instead, we can keep Location up to date to provide this information.

Use case:
I am polling files on an interval, extracting lines between each poll, and need to manually seek based on the final position of the previous poll.