### PR TITLE
feat: fix file change(rename) line loss and duplication

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -2,11 +2,11 @@
 // Copyright (c) 2015 HPE Software Inc. All rights reserved.
 // Copyright (c) 2013 ActiveState Software Inc. All rights reserved.
 
-//nxadm/tail provides a Go library that emulates the features of the BSD `tail`
-//program. The library comes with full support for truncation/move detection as
-//it is designed to work with log rotation tools. The library works on all
-//operating systems supported by Go, including POSIX systems like Linux and
-//*BSD, and MS Windows. Go 1.9 is the oldest compiler release supported.
+// nxadm/tail provides a Go library that emulates the features of the BSD `tail`
+// program. The library comes with full support for truncation/move detection as
+// it is designed to work with log rotation tools. The library works on all
+// operating systems supported by Go, including POSIX systems like Linux and
+// *BSD, and MS Windows. Go 1.9 is the oldest compiler release supported.
 package tail
 
 import (
@@ -21,10 +21,11 @@ import (
 	"sync"
 	"time"
 
+	"gopkg.in/tomb.v1"
+
 	"github.com/nxadm/tail/ratelimiter"
 	"github.com/nxadm/tail/util"
 	"github.com/nxadm/tail/watch"
-	"gopkg.in/tomb.v1"
 )
 
 var (
@@ -381,6 +382,13 @@ func (tail *Tail) waitForChanges() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	// The write event should be handled first
+	select {
+	case <-tail.changes.Modified:
+		return nil
+	default:
 	}
 
 	select {


### PR DESCRIPTION
#72 

When we use tail to collect logs (starting from the beginning of the new file), during file renaming (when flush and rename events occur very close to each other), part of the old log file may not be collected (write event -> truncated event), and the new file may be collected twice (truncated (write -> truncated) and delete events occurring simultaneously). Therefore, an issue fix is proposed.