### PR TITLE
Go 1.16 is the minimum supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test-build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.20.x, 1.19.x, 1.18.x]
+        go-version: [1.21.x, 1.20.x, 1.19.x, 1.18.x, 1.16.x]
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ nxadm/tail provides a Go library that emulates the features of the BSD `tail`
 program. The library comes with full support for truncation/move detection as
 it is designed to work with log rotation tools. The library works on all
 operating systems supported by Go, including POSIX systems like Linux, *BSD,
-MacOS, and MS Windows. Go 1.12 is the oldest compiler release supported.
+MacOS, and MS Windows. Go 1.16 is the oldest compiler release supported.
 
 A simple example:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nxadm/tail
 
-go 1.13
+go 1.16
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/tail.go
+++ b/tail.go
@@ -6,7 +6,7 @@
 //program. The library comes with full support for truncation/move detection as
 //it is designed to work with log rotation tools. The library works on all
 //operating systems supported by Go, including POSIX systems like Linux and
-//*BSD, and MS Windows. Go 1.9 is the oldest compiler release supported.
+//*BSD, and MS Windows. Go 1.16 is the oldest compiler release supported.
 package tail
 
 import (


### PR DESCRIPTION
The PR set the minimum supported version to Go 1.16.

The `tail` library uses `fsnotify v1.6.0` which supports [Go 1.16](https://github.com/fsnotify/fsnotify/blob/5f8c606accbcc6913853fe7e083ee461d181d88d/README.md?plain=1#L4) and above.