### PR TITLE
continue sending output lines read after StopAtEOF was called

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -2,11 +2,11 @@
 // Copyright (c) 2015 HPE Software Inc. All rights reserved.
 // Copyright (c) 2013 ActiveState Software Inc. All rights reserved.
 
-//nxadm/tail provides a Go library that emulates the features of the BSD `tail`
-//program. The library comes with full support for truncation/move detection as
-//it is designed to work with log rotation tools. The library works on all
-//operating systems supported by Go, including POSIX systems like Linux and
-//*BSD, and MS Windows. Go 1.9 is the oldest compiler release supported.
+// nxadm/tail provides a Go library that emulates the features of the BSD `tail`
+// program. The library comes with full support for truncation/move detection as
+// it is designed to work with log rotation tools. The library works on all
+// operating systems supported by Go, including POSIX systems like Linux and
+// *BSD, and MS Windows. Go 1.9 is the oldest compiler release supported.
 package tail
 
 import (
@@ -456,6 +456,10 @@ func (tail *Tail) sendLine(line string) bool {
 		select {
 		case tail.Lines <- &Line{line, tail.lineNum, SeekInfo{Offset: offset}, now, nil}:
 		case <-tail.Dying():
+			if tail.Err() == errStopAtEOF {
+				tail.Lines <- &Line{line, tail.lineNum, SeekInfo{Offset: offset}, now, nil}
+				continue
+			}
 			return true
 		}
 	}


### PR DESCRIPTION
If StopAtEOF is called, then all lines futher read from file are ignored. This fix allows to still return all data read until EOF.

Fixes https://github.com/nxadm/tail/issues/37